### PR TITLE
unite archive

### DIFF
--- a/packages/blog/src/Repository/PostRepository.php
+++ b/packages/blog/src/Repository/PostRepository.php
@@ -79,11 +79,17 @@ final class PostRepository
     }
 
     /**
-     * @return Post[]
+     * @return Post[][]
      */
-    public function fetchByYear(int $year): array
+    public function groupByYear(): array
     {
-        return array_filter($this->fetchAllEnglishNonDeprecated(), fn (Post $post) => $post->getYear() === $year);
+        $postsByYear = [];
+
+        foreach ($this->fetchAllEnglishNonDeprecated() as $post) {
+            $postsByYear[$post->getYear()][] = $post;
+        }
+
+        return $postsByYear;
     }
 
     public function get(int $id): Post

--- a/packages/blog/templates/blog/archive.twig
+++ b/packages/blog/templates/blog/archive.twig
@@ -2,8 +2,11 @@
 
 {% block content %}
     <div class="container-fluid" id="blog">
-        <h1>Posts from {{ year }}</h1>
+        <h1>{{ title }}</h1>
 
-        {% include "_snippets/post/post_list.twig" with { posts: posts } %}
+        {% for year, posts in posts_by_year %}
+            <h2 class="text-center mt-5 mb-5" id="{{ year }}">{{ year }}</h2>
+            {% include "_snippets/post/post_list.twig" with { posts: posts } %}
+        {% endfor %}
     </div>
 {% endblock %}

--- a/src/Controller/BlogArchiveController.php
+++ b/src/Controller/BlogArchiveController.php
@@ -19,16 +19,15 @@ final class BlogArchiveController extends AbstractController
     }
 
     /**
-     * @Route(path="/archive/{year}", name="blog_archive")
+     * @Route(path="/archive", name="blog_archive")
      */
-    public function __invoke(int $year): Response
+    public function __invoke(): Response
     {
-        $postByYear = $this->postRepository->fetchByYear($year);
+        $postsByYear = $this->postRepository->groupByYear();
 
         return $this->render('blog/archive.twig', [
-            'posts' => $postByYear,
-            'title' => 'Archive ' . $year,
-            'year' => $year,
+            'title' => 'Post Archive',
+            'posts_by_year' => $postsByYear,
         ]);
     }
 }

--- a/src/Controller/CleaningLadyListController.php
+++ b/src/Controller/CleaningLadyListController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\Website\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class CleaningLadyListController extends AbstractController
+{
+    /**
+     * @Route(path="cleaning-lady-list", name="cleaning_lady")
+     */
+    public function __invoke(): Response
+    {
+        // @todo value object
+        $checklist = [];
+        $checklist[] = [
+            'headline' => 'composer.json',
+            'items' => [
+                'make sure php version is specified',
+            ]
+        ];
+
+        return $this->render('cleaning_lady_list.twig', [
+            'title' => 'Cleaning Lady list',
+            'checklist' => $checklist
+        ]);
+    }
+}

--- a/templates/_snippets/footer.twig
+++ b/templates/_snippets/footer.twig
@@ -3,6 +3,8 @@
 <script src="/assets/js/cluster-checklist.js?={{ random() }}"></script>
 <script src="/assets/js/cluster-expanable.js?={{ random() }}"></script>
 
+{#<script src="/assets/js/cleaning-lady-checklist.js?={{ random() }}"></script>#}
+
 {# @see https://datatables.net/examples/styling/bootstrap4.html #}
 {# sortable table in php framework trends #}
 <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
@@ -35,7 +37,8 @@
 <div class="text-center mt-5" id="footer">
     <div class="row">
         <div class="col-12">
-            Join 22 912 PHP developers every month: <a href="{{ path('rss') }}">RSS</a>&nbsp;or&nbsp;<a href="https://twitter.com/votrubaT">@votrubaT</a>
+            {# updated from Google Analytics, 2020-04-25 #}
+            Join 25 087 growing PHP developers every month: <a href="https://twitter.com/votrubaT">@votrubaT</a> or <a href="{{ path('rss') }}">RSS</a>
         </div>
     </div>
 
@@ -46,9 +49,12 @@
 
         <a href="https://github.com/sponsors/TomasVotruba">Support me</a>
 
+{#        <span class="pl-2 pr-2">•</span>#}
+{#        <a href="{{ path('cleaning_lady') }}">Cleaning Lady List</a>#}
+
         <span class="hidden-sm-down">
             <span class="pl-2 pr-2">•</span>
-            Hosted with <a href="https://www.statie.org/">Statie</a> on <a href="https://github.com/tomasvotruba/tomasvotruba.com">GitHub</a>
+            Hosted with <a href="https://github.com/symplify/symfony-static-dumper">Symfony Static Dumper</a> on <a href="https://github.com/tomasvotruba/tomasvotruba.com">GitHub</a>
         </span>
     </p>
 </div>

--- a/templates/_snippets/sponsor_button.twig
+++ b/templates/_snippets/sponsor_button.twig
@@ -1,7 +1,0 @@
-<div class="text-center">
-    <a href="https://github.com/sponsors/TomasVotruba" class="btn btn-outline-light d-block mt-3 btn-outline-dark" id="support-me-button">
-        Do you find <strong>these posts helpful</strong>?
-        <div class="hidden-md-up"><br></div>
-        &nbsp;❤️ &nbsp;Support me on GitHub Sponsors&nbsp; <em class="fab fa-github fa-fw"></em>
-    </a>
-</div>

--- a/templates/blog/post.twig
+++ b/templates/blog/post.twig
@@ -9,8 +9,6 @@
 
         <div class="mainContent">
             <div class="container-fluid" id="post">
-                {% include "_snippets/sponsor_button.twig" %}
-
                 <h1>{{ post.title|raw }}</h1>
 
                 {% include "_snippets/post/post_metadata_line.twig" with { "post": post, "show_comment_count": true, "show_edit_link": true } %}

--- a/templates/cleaning_lady_list.twig
+++ b/templates/cleaning_lady_list.twig
@@ -1,0 +1,39 @@
+{% extends "base.twig" %}
+
+{% block content %}
+    <div class="container">
+        <h1>
+            {{ title }}
+            <br>
+            <small>
+                What to do to make Legacy project <strong>shine & clean again</strong>
+            </small>
+        </h1>
+
+        <p>
+            These task are repeated over and over in each new project I on-board.
+        </p>
+        <p>
+            This checklist helps to see <strong class="text-danger">what needs to be done</strong> and <strong class="text-success">what is finished</strong>.
+        </p>
+
+
+        <br>
+
+        <form class="form-inline">
+            <div class="form-group mx-sm-3 mb-2">
+                <label for="project-name" class="sr-only">Name</label>
+                <input type="text" class="form-control" id="project-name" placeholder="Fill your project name">
+            </div>
+            <button type="button" class="btn btn-primary mb-2">Save</button>
+        </form>
+
+        {% for step in checklist %}
+            <h3>{{ step.headline }}</h3>
+
+            {% for item in step.items %}
+                <li>{{ item }}</li>
+            {% endfor %}
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -69,13 +69,7 @@
         </div>
 
         <div class="mt-4">
-            <p>2. Or explore the Archive</p>
-
-            {% for year in (currentYear)..2016 %}
-                <a href="{{ path('blog_archive', {'year': year}) }}" class="btn btn-warning mr-2 mb-3">
-                    Posts {{ year }}
-                </a>
-            {% endfor %}
+            <p>2. Or explore <a href="{{ path('blog_archive') }}">the Archive</a></p>
         </div>
     </div>
 {% endblock %}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -2,8 +2,6 @@
 
 {% block content %}
     <div class="container-fluid" id="blog">
-        {% include "_snippets/sponsor_button.twig" %}
-
         <div class="mt-5 mb-2 subline text-center">
             <p>
                 Do you want to <strong>become lazy and pragmatic programmer</strong>?<br>

--- a/templates/talks.twig
+++ b/templates/talks.twig
@@ -31,9 +31,7 @@
             <div class="card mb-5" id="{{ talk.anchor }}">
                 <div class="text-center card-header">
                     <h2>
-                        <a href="#{{ talk.anchor }}">
-                            {{ talk.title }}
-                        </a>
+                        <a href="#{{ talk.anchor }}">{{ talk.title }}</a>
                     </h2>
                 </div>
                 <div class="card-body">


### PR DESCRIPTION
- merge archive to single one, misc
- remove sponsor on every header


According to Google Analytics, people visit all archives quite often. When they look for a creating post from *that* year... it must be frustrating to click into 3 pages and use CTRL + F. This will make it easier with just one page.

---

# Before

![image](https://user-images.githubusercontent.com/924196/80290024-11d5bc00-8743-11ea-836c-8b64efb659a3.png)

<br>


![image](https://user-images.githubusercontent.com/924196/80290067-4a759580-8743-11ea-92da-99c3d4af1ea7.png)

<br>

# After

![image](https://user-images.githubusercontent.com/924196/80290020-0aaeae00-8743-11ea-8690-e8d0b86c330d.png)

<br>

![image](https://user-images.githubusercontent.com/924196/80290054-39c51f80-8743-11ea-8f85-abc5130141cd.png)


