### PR TITLE
Fix raw text for description

### DIFF
--- a/templates/rss.twig
+++ b/templates/rss.twig
@@ -21,6 +21,7 @@
                 <title><![CDATA[ {{ post.title|replace({'&nbsp;':' '}) }} ]]></title>
                 <link>{{ post_absolute_url }}</link>
                 <description><![CDATA[ {{ post.perex|markdown|raw }} ]]></description>
+                <content:encoded><![CDATA[ {{ post.htmlContent|raw }} ]]></content:encoded>
                 <guid isPermaLink="false">{{ post_absolute_url }}</guid>
                 <dc:creator><![CDATA[ Tomas Votruba ]]></dc:creator>
 

--- a/templates/rss.twig
+++ b/templates/rss.twig
@@ -20,7 +20,7 @@
             <item>
                 <title><![CDATA[ {{ post.title|replace({'&nbsp;':' '}) }} ]]></title>
                 <link>{{ post_absolute_url }}</link>
-                <description><![CDATA[ {{ post.perex|striptags }} ]]></description>
+                <description><![CDATA[ {{ post.perex|markdown|raw }} ]]></description>
                 <guid isPermaLink="false">{{ post_absolute_url }}</guid>
                 <dc:creator><![CDATA[ Tomas Votruba ]]></dc:creator>
 


### PR DESCRIPTION
At this moment RSS returns description as markdown which isn't readable by RSS readers, with this small change it fix problem.
Hope You gonna accept and keep writing! 

(Feedly reader for example)
![image](https://user-images.githubusercontent.com/14053391/89066779-4c687980-d36e-11ea-8bf9-f821c630ac36.png)
