### PR TITLE
Update 2020-03-23-doctrine-entity-typed-properties-with-php74.md

### DIFF
--- a/packages/blog/config/data/2020/2020-03-23-doctrine-entity-typed-properties-with-php74.md
+++ b/packages/blog/config/data/2020/2020-03-23-doctrine-entity-typed-properties-with-php74.md
@@ -173,7 +173,7 @@ You might also use this PHPStan format, but I'm not sure how PHPStorm handles th
  /**
   * @ORM\OneToMany(targetEntity="Pehapkari\Training\Entity\Training", mappedBy="trainer")
 - * @var Collection|Trainer[]
-+ * @var Collection<Trainer>
++ * @var Collection<int, Trainer>
   */
  private Collection $trainings;
 ```


### PR DESCRIPTION
With `@var Collection<Trainer>`, PhpStan gives me (on level 6) - see https://stackoverflow.com/a/64242837/1668200
> Property ... with generic interface Doctrine\Common\Collections\Collection does not specify its types: TKey, T

Question/suggestion: Why do you suggest `Collection` here instead of `ArrayCollection`? What's the difference?