### PR TITLE
Fix SetList usage instead of SymfonySetList

### DIFF
--- a/packages/blog/data/2019/2019-02-28-how-to-upgrade-symfony-2-8-to-3-4.md
+++ b/packages/blog/data/2019/2019-02-28-how-to-upgrade-symfony-2-8-to-3-4.md
@@ -71,11 +71,11 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(SymfonySetList::SYMFONY_28);
     // take it 1 set at a time to so next set works with output of the previous set; I do 1 set per pull-request
-    // $containerConfigurator->import(SetList::SYMFONY_30);
-    // $containerConfigurator->import(SetList::SYMFONY_31);
-    // $containerConfigurator->import(SetList::SYMFONY_32);
-    // $containerConfigurator->import(SetList::SYMFONY_33);
-    // $containerConfigurator->import(SetList::SYMFONY_34);
+    // $containerConfigurator->import(SymfonySetList::SYMFONY_30);
+    // $containerConfigurator->import(SymfonySetList::SYMFONY_31);
+    // $containerConfigurator->import(SymfonySetList::SYMFONY_32);
+    // $containerConfigurator->import(SymfonySetList::SYMFONY_33);
+    // $containerConfigurator->import(SymfonySetList::SYMFONY_34);
 
     // set paths to directories with your code
     $parameters = $containerConfigurator->parameters();


### PR DESCRIPTION
For Symfony 3.0 to Symfony 3.4 the class is `SetList` instead of `SymfonySetList`