### PR TITLE
added deprecation message

### DIFF
--- a/packages/blog/data/2019/2019-11-11-from-0-doc-types-to-full-type-declaration-with-dynamic-analysis.md
+++ b/packages/blog/data/2019/2019-11-11-from-0-doc-types-to-full-type-declaration-with-dynamic-analysis.md
@@ -13,6 +13,10 @@ perex: |
 tweet: "New Post on #php 🐘 blog: From 0 Doc Types to Full Type Declaration with Dynamic Analysis - Thank you @DaveLiddament for injecting the idea to my head"
 tweet_image: "/assets/images/posts/2019/dynamic-analysis/probe.png"
 
+deprecated_since: "November 2020"
+deprecated_message: |
+    `DynamicTypeAnalysis` was removed from Rector on November 30, 2020 as it was not alligned with Rector philosophy of instant refactoring and was way too theoretical.
+
 updated_since: "August 2020"
 updated_message: |
     Updated Rector YAML to PHP configuration, as current standard.


### PR DESCRIPTION
the post https://tomasvotruba.com/blog/2019/11/11/from-0-doc-types-to-full-type-declaration-with-dynamic-analysis/ 

covers a really similar topic as https://tomasvotruba.com/blog/2019/01/03/how-to-complete-type-declarations-without-docblocks-with-rector/ and the underlying mechanics were deprecated... 

therefore I think this post should also be considered deprecated