### PR TITLE
Update 2021-10-25-when-symfony-http-kernel-is-too-big-hammer-to-use.md

### DIFF
--- a/packages/blog/data/2021/2021-10-25-when-symfony-http-kernel-is-too-big-hammer-to-use.md
+++ b/packages/blog/data/2021/2021-10-25-when-symfony-http-kernel-is-too-big-hammer-to-use.md
@@ -160,11 +160,11 @@ The problem is not about invalid contracts, and anyone could make a mistake in t
 I wish there were a more straightforward container factory service that we could add to the project:
 
 ```bash
-symfony/dependnecy-container-factory
+symfony/dependency-container-factory
 
 Installing...
-* symfony/dependnecy-container-factory
-* symfony/dependnecy-injection
+* symfony/dependency-container-factory
+* symfony/dependency-injection
 ```
 
 <br>


### PR DESCRIPTION
fix "dependency" typos