### PR TITLE
Update 2018-11-15-how-to-get-php-74-typed-properties-to-your-code-in-…

### DIFF
--- a/packages/blog/data/2018/2018-11-15-how-to-get-php-74-typed-properties-to-your-code-in-few-seconds.md
+++ b/packages/blog/data/2018/2018-11-15-how-to-get-php-74-typed-properties-to-your-code-in-few-seconds.md
@@ -170,7 +170,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 return function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
-    $services->set(TypedPropertyRector::class);
+    $services->set(TypedPropertyRector::class)
+    ->configure([
+            TypedPropertyRector::INLINE_PUBLIC => true,
+        ]);
 };
 ```
 

--- a/packages/blog/data/2018/2018-11-15-how-to-get-php-74-typed-properties-to-your-code-in-few-seconds.md
+++ b/packages/blog/data/2018/2018-11-15-how-to-get-php-74-typed-properties-to-your-code-in-few-seconds.md
@@ -171,7 +171,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(TypedPropertyRector::class)
-    ->configure([
+        ->configure([
             TypedPropertyRector::INLINE_PUBLIC => true,
         ]);
 };


### PR DESCRIPTION
…few-seconds.md

For described modification of public properties reader has to re-configure default rule configuration of `TypedPropertyRector::INLINE_PUBLIC` to `true`