### PR TITLE
Fixed code block syntax

### DIFF
--- a/resources/posts/2018/2018-06-07-how-to-migrate-from-php-cs-fixer-to-easy-coding-standard.md
+++ b/resources/posts/2018/2018-06-07-how-to-migrate-from-php-cs-fixer-to-easy-coding-standard.md
@@ -189,7 +189,7 @@ to ECS equivalent:
 ```bash
 vendor/bin/ecs check
 vendor/bin/ecs check --fix
-``
+```
 
 ## 6. From `@Rules` to `withPhpCsFixerSets()` Method
 


### PR DESCRIPTION
Fixed code block syntax causing the blog style to not be presented correctly.

https://tomasvotruba.com/blog/2018/06/07/how-to-migrate-from-php-cs-fixer-to-easy-coding-standard#:~:text=cs%2Dfixer%20fix-,to%20ECS%20equivalent%3A,-vendor/bin/ecs