### PR TITLE
Remove unnecessary check $this->posts[$slug] on PostRepository

### DIFF
--- a/app/Repository/PostRepository.php
+++ b/app/Repository/PostRepository.php
@@ -43,10 +43,6 @@ final class PostRepository
             }
         }
 
-        if (isset($this->posts[$slug])) {
-            return $this->posts[$slug];
-        }
-
         throw new ShouldNotHappenException(sprintf('Post for slug "%s" was not found.', $slug));
     }
 


### PR DESCRIPTION
slug seems never be a key, it is the values of the `$this->posts` data, so mark slug as key always never exists, see

https://github.com/TomasVotruba/tomasvotruba.com/blob/08a6986ad9211d703ffff1a9d4aead189a4e0d6f/app/Repository/PostRepository.php#L79

use loop and compare its value instead per previous check.