### PR TITLE
Use NotFoundHttpException to produce 404 page on slug not found

### DIFF
--- a/app/Repository/PostRepository.php
+++ b/app/Repository/PostRepository.php
@@ -7,6 +7,7 @@ namespace App\Repository;
 use App\Entity\Post;
 use App\EntityFactory\PostFactory;
 use App\Exception\ShouldNotHappenException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Webmozart\Assert\Assert;
 
 /**
@@ -43,7 +44,7 @@ final class PostRepository
             }
         }
 
-        throw new ShouldNotHappenException(sprintf('Post for slug "%s" was not found.', $slug));
+        throw new NotFoundHttpException(sprintf('Post for slug "%s" was not found.', $slug));
     }
 
     /**


### PR DESCRIPTION
On prod environment with debug 0, it should provide 404 page instead of 500 when it pointed to invalid slug:

**Before**

![Screenshot 2024-08-03 at 21 40 49](https://github.com/user-attachments/assets/25de114a-b717-4898-87ac-d43d421b0c6f)


**After**

![Screenshot 2024-08-03 at 21 40 15](https://github.com/user-attachments/assets/4140240d-9930-491f-8c8e-2fd4f6ca3f04)
