### PR TITLE
docs: update phpspec migration blog post

### DIFF
--- a/resources/posts/2019/2019-03-21-how-to-instantly-migrate-phpspec-to-phpunit.md
+++ b/resources/posts/2019/2019-03-21-how-to-instantly-migrate-phpspec-to-phpunit.md
@@ -167,21 +167,31 @@ First, take a 2-week paid vacation... Just kidding. Start with Rector which migr
 composer require rector/rector --dev
 ```
 
-2. Create `rector.php` config
+2. Add the specific rule
+
+```bash
+composer require rector/custom-phpspec-to-phpunit --dev
+```
+
+3. Create `rector.php` config
 
 ```php
-use Rector\Set\ValueObject\SetList;
+<?php
+
+declare(strict_types=1);
+
 use Rector\Config\RectorConfig;
+use Rector\PhpSpecToPHPUnit\Set\MigrationSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([SetList::PHPSPEC_TO_PHPUNIT]);
+    $rectorConfig->sets([MigrationSetList::PHPSPEC_TO_PHPUNIT]);
 };
 ```
 
-3. Run Rector on your tests directories
+4. Run Rector on your spec directories
 
 ```bash
-vendor/bin/rector process tests
+vendor/bin/rector process spec
 ```
 
 <br>


### PR DESCRIPTION
Hi, 
I was checking on how to migrate phpspec to phpunit when I found your blog article about it https://tomasvotruba.com/blog/2019/03/21/how-to-instantly-migrate-phpspec-to-phpunit

I tried it and figured I missed some information to make it work properly. 
Here is a PR to fix the article acording to that. 

By the way, thank you for your amazing work for the whole php community. 